### PR TITLE
Integrating date filters with custom filtering

### DIFF
--- a/AVSwift/AVSwift.xcodeproj/project.pbxproj
+++ b/AVSwift/AVSwift.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		014410501FFC0B6400B5675B /* AVHistoricalStockPricesQueryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0144104F1FFC0B6400B5675B /* AVHistoricalStockPricesQueryBuilder.swift */; };
 		014410591FFC518E00B5675B /* AVStockDataFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014410581FFC518E00B5675B /* AVStockDataFetcher.swift */; };
 		0144105D1FFC54AB00B5675B /* AVQueryBuilderCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0144105C1FFC54AB00B5675B /* AVQueryBuilderCommon.swift */; };
-		016E2E8E2042821D0038CE32 /* AVModelFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016E2E8D2042821D0038CE32 /* AVModelFilter.swift */; };
 		0172A6802002D908006EF18D /* AVSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 014410011FFB039700B5675B /* AVSwift.framework */; };
 		0172A6832002D98A006EF18D /* AVHistoricalStockPriceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0172A6822002D98A006EF18D /* AVHistoricalStockPriceModel.swift */; };
 		01732EB82020556C002FDB91 /* AVKeychainQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732EB72020556C002FDB91 /* AVKeychainQuery.swift */; };
@@ -23,6 +22,8 @@
 		01732ED0202EDE03002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ECF202EDE03002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift */; };
 		01732ED4202FDEB5002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED3202FDEB4002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */; };
 		01732ED820301503002FDB91 /* AVModelParsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED720301503002FDB91 /* AVModelParsingError.swift */; };
+		01C4F47F2043603E00A2226E /* AVDateFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F47E2043603E00A2226E /* AVDateFilter.swift */; };
+		01C4F4832043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F4822043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift */; };
 		01F36D50200B094C00512ABC /* AVAPIKeyRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F36D4F200B094C00512ABC /* AVAPIKeyRegistrar.swift */; };
 /* End PBXBuildFile section */
 
@@ -37,7 +38,6 @@
 		0144104F1FFC0B6400B5675B /* AVHistoricalStockPricesQueryBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVHistoricalStockPricesQueryBuilder.swift; sourceTree = "<group>"; };
 		014410581FFC518E00B5675B /* AVStockDataFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AVStockDataFetcher.swift; path = AVSwift/DataFetchers/AVStockDataFetcher.swift; sourceTree = SOURCE_ROOT; };
 		0144105C1FFC54AB00B5675B /* AVQueryBuilderCommon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVQueryBuilderCommon.swift; sourceTree = "<group>"; };
-		016E2E8D2042821D0038CE32 /* AVModelFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AVModelFilter.swift; path = AVSwift/Models/AVModelFilter.swift; sourceTree = SOURCE_ROOT; };
 		0172A6822002D98A006EF18D /* AVHistoricalStockPriceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVHistoricalStockPriceModel.swift; sourceTree = "<group>"; };
 		01732EB72020556C002FDB91 /* AVKeychainQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVKeychainQuery.swift; sourceTree = "<group>"; };
 		01732EBB2021A832002FDB91 /* AVAPIKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAPIKeyStore.swift; sourceTree = "<group>"; };
@@ -46,6 +46,8 @@
 		01732ECF202EDE03002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVHistoricalTimeSeriesPeriodicity.swift; sourceTree = "<group>"; };
 		01732ED3202FDEB4002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVHistoricalAdjustedStockPriceModel.swift; sourceTree = "<group>"; };
 		01732ED720301503002FDB91 /* AVModelParsingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVModelParsingError.swift; sourceTree = "<group>"; };
+		01C4F47E2043603E00A2226E /* AVDateFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AVDateFilter.swift; path = AVSwift/DataFetchers/AVDateFilter.swift; sourceTree = SOURCE_ROOT; };
+		01C4F4822043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVHistoricalStockPriceQueryProtocols.swift; sourceTree = "<group>"; };
 		01F36D4F200B094C00512ABC /* AVAPIKeyRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAPIKeyRegistrar.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -113,7 +115,7 @@
 		014410561FFC50C300B5675B /* DataFetchers */ = {
 			isa = PBXGroup;
 			children = (
-				016E2E8D2042821D0038CE32 /* AVModelFilter.swift */,
+				01C4F47E2043603E00A2226E /* AVDateFilter.swift */,
 				014410581FFC518E00B5675B /* AVStockDataFetcher.swift */,
 			);
 			name = DataFetchers;
@@ -123,6 +125,7 @@
 		014410571FFC50D400B5675B /* QueryBuilders */ = {
 			isa = PBXGroup;
 			children = (
+				01C4F4822043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift */,
 				01732ECF202EDE03002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift */,
 				014410431FFB538700B5675B /* AVQueryBuilder.swift */,
 				0144105C1FFC54AB00B5675B /* AVQueryBuilderCommon.swift */,
@@ -280,12 +283,13 @@
 				01732EB82020556C002FDB91 /* AVKeychainQuery.swift in Sources */,
 				014410591FFC518E00B5675B /* AVStockDataFetcher.swift in Sources */,
 				01F36D50200B094C00512ABC /* AVAPIKeyRegistrar.swift in Sources */,
+				01C4F4832043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift in Sources */,
 				01732EC720243838002FDB91 /* AVDescriptionHelper.swift in Sources */,
 				0144105D1FFC54AB00B5675B /* AVQueryBuilderCommon.swift in Sources */,
 				01732ED820301503002FDB91 /* AVModelParsingError.swift in Sources */,
 				01732ED4202FDEB5002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift in Sources */,
 				014410501FFC0B6400B5675B /* AVHistoricalStockPricesQueryBuilder.swift in Sources */,
-				016E2E8E2042821D0038CE32 /* AVModelFilter.swift in Sources */,
+				01C4F47F2043603E00A2226E /* AVDateFilter.swift in Sources */,
 				01732EBC2021A832002FDB91 /* AVAPIKeyStore.swift in Sources */,
 				01732ED0202EDE03002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift in Sources */,
 				01732ECC20243E54002FDB91 /* AVDateFormatter.swift in Sources */,

--- a/AVSwift/AVSwift/DataFetchers/AVModelFilter.swift
+++ b/AVSwift/AVSwift/DataFetchers/AVModelFilter.swift
@@ -8,29 +8,25 @@
 
 import UIKit
 
-public protocol AVModelFilter {
-  func filterStandard(_: AVHistoricalStockPriceModel) -> Bool
-  func filterAdjusted(_: AVHistoricalAdjustedStockPriceModel) -> Bool
-}
-
-public extension AVModelFilter {
-  func filterStandard(_: AVHistoricalStockPriceModel) -> Bool {
-    return true
-  }
-  
-  func filterAdjusted(_: AVHistoricalAdjustedStockPriceModel) -> Bool {
-    return true
-  }
-}
-
-public enum AVDateFilter {
+public enum AVDateFilter<T> {
   case after(Date)
   case before(Date)
   case between(Date, Date)
-}
-
-extension AVDateFilter: AVModelFilter {
-  public func filterStandard(_ model: AVHistoricalStockPriceModel) -> Bool {
+  
+  public func filter(_ model: T) -> Bool
+  {
+    switch model.self {
+    case is AVHistoricalStockPriceModel:
+      return filterStandard(model as! AVHistoricalStockPriceModel)
+    case is AVHistoricalAdjustedStockPriceModel :
+      return filterAdjusted(model as! AVHistoricalAdjustedStockPriceModel)
+    default:
+      return false
+    }
+  }
+  
+  private func filterStandard(_ model: AVHistoricalStockPriceModel) -> Bool
+  {
     switch self {
     case .after(let afterDate):
       return model.date >= afterDate
@@ -41,7 +37,8 @@ extension AVDateFilter: AVModelFilter {
     }
   }
   
-  public func filterAdjusted(_ model: AVHistoricalAdjustedStockPriceModel) -> Bool {
+  private func filterAdjusted(_ model: AVHistoricalAdjustedStockPriceModel) -> Bool
+  {
     switch self {
     case .after(let afterDate):
       return model.date >= afterDate

--- a/AVSwift/AVSwift/QueryBuilders/AVHistoricalStockPricesQueryBuilder.swift
+++ b/AVSwift/AVSwift/QueryBuilders/AVHistoricalStockPricesQueryBuilder.swift
@@ -8,13 +8,6 @@
 
 import UIKit
 
-// MARK: AVHistoricalStockPricesBuilderProtocol
-
-public protocol AVHistoricalStockPricesBuilderProtocol : AVQueryBuilderBase {
-  func setSymbol(_ symbol: String) -> Self
-  func setPeriodicity(_ periodicity: AVHistoricalTimeSeriesPeriodicity) -> Self
-}
-
 // MARK: AVHistoricalStockPricesQueryBuilderBase
 
 public class AVHistoricalStockPricesQueryBuilderBase: AVQueryBuilder {
@@ -61,15 +54,17 @@ extension AVHistoricalStockPricesQueryBuilderBase: AVHistoricalStockPricesBuilde
 
 // MARK: AVHistoricalStandardStockPricesBuilder
 
-public class AVHistoricalStandardStockPricesBuilder: AVHistoricalStockPricesQueryBuilderBase {
+public final class AVHistoricalStandardStockPricesBuilder: AVHistoricalStockPricesQueryBuilderBase {
   
   public typealias ModelType = AVHistoricalStockPriceModel
-  var modelFilters: [ModelFilter<ModelType>] = []
+  internal var modelFilters: [ModelFilter<ModelType>] = []
   
   public init() {
     super.init(withAdjustedPrices: false)
   }
-  
+}
+
+extension AVHistoricalStandardStockPricesBuilder: AVHistoricalStockPricesFiltering {
   public func withFilter(_ filter: @escaping ModelFilter<ModelType>) -> Self {
     modelFilters.append(filter)
     return self
@@ -80,19 +75,22 @@ extension AVHistoricalStandardStockPricesBuilder: AVQueryBuilderProtocol {}
 
 // MARK: AVHistoricalAdjustedStockPricesBuilder
 
-public class AVHistoricalAdjustedStockPricesBuilder: AVHistoricalStockPricesQueryBuilderBase {
+public final class AVHistoricalAdjustedStockPricesBuilder: AVHistoricalStockPricesQueryBuilderBase {
   
   public typealias ModelType = AVHistoricalAdjustedStockPriceModel
-  var modelFilters: [ModelFilter<ModelType>] = []
+  internal var modelFilters: [ModelFilter<ModelType>] = []
   
   public init() {
     super.init(withAdjustedPrices: true)
   }
+}
+
+extension AVHistoricalAdjustedStockPricesBuilder: AVHistoricalStockPricesFiltering {
   
   public func withFilter(_ filter: @escaping ModelFilter<ModelType>) -> Self {
     modelFilters.append(filter)
     return self
   }
+  
 }
-
 extension AVHistoricalAdjustedStockPricesBuilder: AVQueryBuilderProtocol {}

--- a/AVTestApp/AVTestApp.xcodeproj/project.pbxproj
+++ b/AVTestApp/AVTestApp.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		0144102D1FFB045600B5675B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0144102B1FFB045600B5675B /* Main.storyboard */; };
 		0144102F1FFB045600B5675B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0144102E1FFB045600B5675B /* Assets.xcassets */; };
 		014410321FFB045600B5675B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 014410301FFB045600B5675B /* LaunchScreen.storyboard */; };
-		016E2E922042827E0038CE32 /* AVModelFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016E2E912042827E0038CE32 /* AVModelFilter.swift */; };
 		01732EBA2020569B002FDB91 /* AVKeychainQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732EB92020569B002FDB91 /* AVKeychainQuery.swift */; };
 		01732EBE2021A9C2002FDB91 /* AVAPIKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732EBD2021A9C2002FDB91 /* AVAPIKeyStore.swift */; };
 		01732ECA202438CE002FDB91 /* AVDescriptionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732EC9202438CE002FDB91 /* AVDescriptionHelper.swift */; };
@@ -20,6 +19,8 @@
 		01732ED2202EDE26002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED1202EDE26002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift */; };
 		01732ED6202FDF30002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED5202FDF30002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */; };
 		01732EDA20301528002FDB91 /* AVModelParsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED920301528002FDB91 /* AVModelParsingError.swift */; };
+		01C4F48120436ED200A2226E /* AVDateFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F48020436ED200A2226E /* AVDateFilter.swift */; };
+		01C4F4852043723700A2226E /* AVHistoricalStockPriceQueryProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F4842043723700A2226E /* AVHistoricalStockPriceQueryProtocols.swift */; };
 		01F36D7A200B166100512ABC /* AVStockDataFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F36D71200B166000512ABC /* AVStockDataFetcher.swift */; };
 		01F36D7B200B166100512ABC /* AVHistoricalStockPriceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F36D73200B166000512ABC /* AVHistoricalStockPriceModel.swift */; };
 		01F36D7C200B166100512ABC /* AVHistoricalStockPricesQueryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F36D75200B166100512ABC /* AVHistoricalStockPricesQueryBuilder.swift */; };
@@ -49,7 +50,6 @@
 		0144102E1FFB045600B5675B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		014410311FFB045600B5675B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		014410331FFB045600B5675B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		016E2E912042827E0038CE32 /* AVModelFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVModelFilter.swift; sourceTree = "<group>"; };
 		01732EB92020569B002FDB91 /* AVKeychainQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVKeychainQuery.swift; sourceTree = "<group>"; };
 		01732EBD2021A9C2002FDB91 /* AVAPIKeyStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVAPIKeyStore.swift; sourceTree = "<group>"; };
 		01732EC9202438CE002FDB91 /* AVDescriptionHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVDescriptionHelper.swift; sourceTree = "<group>"; };
@@ -57,6 +57,8 @@
 		01732ED1202EDE26002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVHistoricalTimeSeriesPeriodicity.swift; sourceTree = "<group>"; };
 		01732ED5202FDF30002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVHistoricalAdjustedStockPriceModel.swift; sourceTree = "<group>"; };
 		01732ED920301528002FDB91 /* AVModelParsingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVModelParsingError.swift; sourceTree = "<group>"; };
+		01C4F48020436ED200A2226E /* AVDateFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVDateFilter.swift; sourceTree = "<group>"; };
+		01C4F4842043723700A2226E /* AVHistoricalStockPriceQueryProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVHistoricalStockPriceQueryProtocols.swift; sourceTree = "<group>"; };
 		01F36D6E200B160300512ABC /* AVSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVSwift.framework; path = "../../../Library/Developer/Xcode/DerivedData/AVSwift-chlcdcxmrbdxjndhzkkodlksfgkm/Build/Products/Release-iphonesimulator/AVSwift.framework"; sourceTree = "<group>"; };
 		01F36D71200B166000512ABC /* AVStockDataFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVStockDataFetcher.swift; sourceTree = "<group>"; };
 		01F36D73200B166000512ABC /* AVHistoricalStockPriceModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVHistoricalStockPriceModel.swift; sourceTree = "<group>"; };
@@ -133,7 +135,7 @@
 		01F36D70200B166000512ABC /* DataFetchers */ = {
 			isa = PBXGroup;
 			children = (
-				016E2E912042827E0038CE32 /* AVModelFilter.swift */,
+				01C4F48020436ED200A2226E /* AVDateFilter.swift */,
 				01F36D71200B166000512ABC /* AVStockDataFetcher.swift */,
 			);
 			name = DataFetchers;
@@ -154,6 +156,7 @@
 		01F36D74200B166100512ABC /* QueryBuilders */ = {
 			isa = PBXGroup;
 			children = (
+				01C4F4842043723700A2226E /* AVHistoricalStockPriceQueryProtocols.swift */,
 				01732ED1202EDE26002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift */,
 				01F36D75200B166100512ABC /* AVHistoricalStockPricesQueryBuilder.swift */,
 				01F36D76200B166100512ABC /* AVQueryBuilder.swift */,
@@ -255,12 +258,13 @@
 				01F36D7D200B166100512ABC /* AVQueryBuilder.swift in Sources */,
 				01732EDA20301528002FDB91 /* AVModelParsingError.swift in Sources */,
 				01F36D7E200B166100512ABC /* AVQueryBuilderCommon.swift in Sources */,
+				01C4F48120436ED200A2226E /* AVDateFilter.swift in Sources */,
 				01732ECE20243ED2002FDB91 /* AVDateFormatter.swift in Sources */,
 				01732EBE2021A9C2002FDB91 /* AVAPIKeyStore.swift in Sources */,
 				01732ECA202438CE002FDB91 /* AVDescriptionHelper.swift in Sources */,
 				01732EBA2020569B002FDB91 /* AVKeychainQuery.swift in Sources */,
-				016E2E922042827E0038CE32 /* AVModelFilter.swift in Sources */,
 				014410281FFB045600B5675B /* AppDelegate.swift in Sources */,
+				01C4F4852043723700A2226E /* AVHistoricalStockPriceQueryProtocols.swift in Sources */,
 				01F36D7B200B166100512ABC /* AVHistoricalStockPriceModel.swift in Sources */,
 				01F36D7F200B166100512ABC /* AVAPIKeyRegistrar.swift in Sources */,
 			);

--- a/AVTestApp/AVTestApp/ViewController.swift
+++ b/AVTestApp/AVTestApp/ViewController.swift
@@ -74,13 +74,15 @@ class ViewController: UIViewController {
   
   private func fetchStandardPrices() {
     print("Periodicity: \(selectedPeriodicity)")
-    let date = try! Date.from(month: 1, day: 1, year: 2018)
+    let beginDate = try! Date.from(month: 11, day: 1, year: 2017)
+    let endDate = try! Date.from(month: 1, day: 1, year: 2018)
     AVHistoricalStandardStockPricesBuilder()
       .setSymbol("MSFT")
       .setPeriodicity(selectedPeriodicity)
-      .withFilter({ model -> Bool in
-        return model.date > date
-      })
+      .withDateFilter(AVDateFilter.between(beginDate, endDate))
+      .withFilter { model -> Bool in
+        return model.close > 85.0
+      }
       .getResults { (stocks, error) in
         print(stocks as Any)
         print(error as Any)


### PR DESCRIPTION
Integrating date filter with the withFilter logic and fixing the issue with using protocol extensions for common logic.
In the end I think it's better that withFilter is defined on the concrete class instead of in a protocol extension because then we don't have to expose the modelFilters var for everyone to see.