### PR TITLE
Changing output size if there is a date filter

### DIFF
--- a/AVSwift/AVSwift/QueryBuilders/AVHistoricalStockPriceQueryProtocols.swift
+++ b/AVSwift/AVSwift/QueryBuilders/AVHistoricalStockPriceQueryProtocols.swift
@@ -10,15 +10,16 @@ import UIKit
 
 // MARK: AVHistoricalStockPricesBuilderProtocol
 
-public protocol AVHistoricalStockPricesBuilderProtocol : class, AVQueryBuilderBase {
+protocol AVHistoricalStockPricesBuilderProtocol : class, AVQueryBuilderBase {
   func setSymbol(_ symbol: String) -> Self
   func setPeriodicity(_ periodicity: AVHistoricalTimeSeriesPeriodicity) -> Self
 }
 
 // MARK: AVHistoricalStockPricesFiltering
 
-public protocol AVHistoricalStockPricesFiltering: class {
+protocol AVHistoricalStockPricesFiltering: class {
   associatedtype ModelType
+  var hasDateFilter: Bool { get set }
   
   func withFilter(_ filter: @escaping ModelFilter<ModelType>) -> Self
   func withDateFilter(_ dateFilter: AVDateFilter<ModelType>) -> Self
@@ -27,6 +28,7 @@ public protocol AVHistoricalStockPricesFiltering: class {
 extension AVHistoricalStockPricesFiltering {
   public func withDateFilter(_ dateFilter: AVDateFilter<ModelType>) -> Self
   {
+    hasDateFilter = true
     return withFilter(dateFilter.filter)
   }
 }

--- a/AVSwift/AVSwift/QueryBuilders/AVHistoricalStockPricesQueryBuilder.swift
+++ b/AVSwift/AVSwift/QueryBuilders/AVHistoricalStockPricesQueryBuilder.swift
@@ -58,6 +58,13 @@ public final class AVHistoricalStandardStockPricesBuilder: AVHistoricalStockPric
   
   public typealias ModelType = AVHistoricalStockPriceModel
   internal var modelFilters: [ModelFilter<ModelType>] = []
+  internal var hasDateFilter: Bool = false {
+    didSet {
+      if hasDateFilter {
+        self.outputSize = .full
+      }
+    }
+  }
   
   public init() {
     super.init(withAdjustedPrices: false)
@@ -79,6 +86,13 @@ public final class AVHistoricalAdjustedStockPricesBuilder: AVHistoricalStockPric
   
   public typealias ModelType = AVHistoricalAdjustedStockPriceModel
   internal var modelFilters: [ModelFilter<ModelType>] = []
+  internal var hasDateFilter: Bool = false {
+    didSet {
+      if hasDateFilter {
+        self.outputSize = .full
+      }
+    }
+  }
   
   public init() {
     super.init(withAdjustedPrices: true)

--- a/AVTestApp/AVTestApp/ViewController.swift
+++ b/AVTestApp/AVTestApp/ViewController.swift
@@ -76,8 +76,8 @@ class ViewController: UIViewController {
   
   private func fetchStandardPrices() {
     print("Periodicity: \(selectedPeriodicity)")
-    let beginDate = try! Date.from(month: 11, day: 1, year: 2017)
-    let endDate = try! Date.from(month: 1, day: 1, year: 2018)
+    let beginDate = try! Date.from(month: 11, day: 1, year: 2003)
+    let endDate = try! Date.from(month: 1, day: 1, year: 2005)
     AVHistoricalStandardStockPricesBuilder()
       .setSymbol("MSFT")
       .setPeriodicity(selectedPeriodicity)


### PR DESCRIPTION
If there is a date filter we need to make sure to change the output size to .full from .compact, otherwise the appropriate dates might never be fetched.
A future optimization would be to have a heuristic that calculates whether or not to fetch the full output or if the compact version is sufficient.