### PR TITLE
Performance optimization to parsing and concurrency

### DIFF
--- a/AVSwift/AVSwift.xcodeproj/project.pbxproj
+++ b/AVSwift/AVSwift.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		01732ED0202EDE03002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ECF202EDE03002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift */; };
 		01732ED4202FDEB5002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED3202FDEB4002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */; };
 		01732ED820301503002FDB91 /* AVModelParsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED720301503002FDB91 /* AVModelParsingError.swift */; };
+		01A2FE6C204B94D600790FDC /* AVPerformanceTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A2FE6B204B94D600790FDC /* AVPerformanceTimer.swift */; };
 		01C4F47F2043603E00A2226E /* AVDateFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F47E2043603E00A2226E /* AVDateFilter.swift */; };
 		01C4F4832043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F4822043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift */; };
 		01C4F4872043C7AD00A2226E /* AVDateOrderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F4862043C7AD00A2226E /* AVDateOrderable.swift */; };
@@ -47,6 +48,7 @@
 		01732ECF202EDE03002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVHistoricalTimeSeriesPeriodicity.swift; sourceTree = "<group>"; };
 		01732ED3202FDEB4002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVHistoricalAdjustedStockPriceModel.swift; sourceTree = "<group>"; };
 		01732ED720301503002FDB91 /* AVModelParsingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVModelParsingError.swift; sourceTree = "<group>"; };
+		01A2FE6B204B94D600790FDC /* AVPerformanceTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVPerformanceTimer.swift; sourceTree = "<group>"; };
 		01C4F47E2043603E00A2226E /* AVDateFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AVDateFilter.swift; path = AVSwift/DataFetchers/AVDateFilter.swift; sourceTree = SOURCE_ROOT; };
 		01C4F4822043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVHistoricalStockPriceQueryProtocols.swift; sourceTree = "<group>"; };
 		01C4F4862043C7AD00A2226E /* AVDateOrderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVDateOrderable.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 				01F36D4F200B094C00512ABC /* AVAPIKeyRegistrar.swift */,
 				01732EBB2021A832002FDB91 /* AVAPIKeyStore.swift */,
 				01732EB72020556C002FDB91 /* AVKeychainQuery.swift */,
+				01A2FE6B204B94D600790FDC /* AVPerformanceTimer.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -292,6 +295,7 @@
 				0144105D1FFC54AB00B5675B /* AVQueryBuilderCommon.swift in Sources */,
 				01732ED820301503002FDB91 /* AVModelParsingError.swift in Sources */,
 				01732ED4202FDEB5002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift in Sources */,
+				01A2FE6C204B94D600790FDC /* AVPerformanceTimer.swift in Sources */,
 				014410501FFC0B6400B5675B /* AVHistoricalStockPricesQueryBuilder.swift in Sources */,
 				01C4F47F2043603E00A2226E /* AVDateFilter.swift in Sources */,
 				01732EBC2021A832002FDB91 /* AVAPIKeyStore.swift in Sources */,

--- a/AVSwift/AVSwift.xcodeproj/xcshareddata/xcbaselines/014410091FFB039700B5675B.xcbaseline/314B47B5-7EA6-4ED2-A7F5-87600ED0E76D.plist
+++ b/AVSwift/AVSwift.xcodeproj/xcshareddata/xcbaselines/014410091FFB039700B5675B.xcbaseline/314B47B5-7EA6-4ED2-A7F5-87600ED0E76D.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>AVSwiftTests</key>
+		<dict>
+			<key>testConcurrent()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.371</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testSerial()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.555</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/AVSwift/AVSwift.xcodeproj/xcshareddata/xcbaselines/014410091FFB039700B5675B.xcbaseline/Info.plist
+++ b/AVSwift/AVSwift.xcodeproj/xcshareddata/xcbaselines/014410091FFB039700B5675B.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>314B47B5-7EA6-4ED2-A7F5-87600ED0E76D</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i5</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2600</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>modelCode</key>
+				<string>Macmini7,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>2</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone9,1</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/AVSwift/AVSwift/Extensions/AVDateFormatter.swift
+++ b/AVSwift/AVSwift/Extensions/AVDateFormatter.swift
@@ -8,14 +8,30 @@
 
 import UIKit
 
+fileprivate let sharedDateFormatter = AVDateFormatter.dateFormatter()
+
 public enum AVDateFormatterError: Error {
   case invalidString(String)
 }
 
+internal class AVDateFormatter {
+  
+  fileprivate static func dateFormatter() -> DateFormatter {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    return dateFormatter
+  }
+  
+  fileprivate static var shared: DateFormatter {
+    get {
+      return sharedDateFormatter
+    }
+  }
+}
+
 extension String {
   func toDate() throws -> Date {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd"
+    let formatter = AVDateFormatter.shared
     guard let date = formatter.date(from: self) else {
       throw AVDateFormatterError.invalidString("Invalid date string: \(self)")
     }

--- a/AVSwift/AVSwift/Utilities/AVPerformanceTimer.swift
+++ b/AVSwift/AVSwift/Utilities/AVPerformanceTimer.swift
@@ -1,0 +1,26 @@
+//
+//  AVPerformanceTimer.swift
+//  AVSwift
+//
+//  Created by Roshan Goli on 3/3/18.
+//  Copyright © 2018 Roshan. All rights reserved.
+//
+
+import UIKit
+
+internal class AVPerformanceTimer {
+  let startTime: Date
+  var endTime: Date!
+  init() {
+    startTime = Date()
+  }
+  
+  public func stop(_ message: String) {
+    let totalTime = self.stop()
+    print(message, totalTime)
+  }
+  
+  public func stop() -> TimeInterval {
+    return DateInterval(start: startTime, end: Date()).duration
+  }
+}

--- a/AVSwift/AVSwiftTests/AVSwiftTests.swift
+++ b/AVSwift/AVSwiftTests/AVSwiftTests.swift
@@ -42,7 +42,30 @@ class AVSwiftTests: XCTestCase {
     self.measure {
        let _ = AVStockDataFetcher<AVHistoricalStockPriceModel>.serialParsing(
         input: testResults!,
-        modelFilters: [(AVHistoricalStockPriceModel) -> Bool]())
+        withFilters: [],
+        config: AVStockFetcherConfiguration())
+    }
+  }
+  
+  func testConcurrent() {
+    let queue = DispatchQueue(label: "synchronous")
+    var testResults: [String: [String: String]]? = nil
+    queue.sync {
+      AVHistoricalStandardStockPricesBuilder()
+        .setOutputSize(.full)
+        .setSymbol("MSFT")
+        .getRawResults { results, error in
+          testResults = results
+      }
+      sleep(5)
+    }
+    XCTAssertNotNil(testResults)
+    
+    self.measure {
+      let _ = AVStockDataFetcher<AVHistoricalStockPriceModel>.concurrentParsing(
+        input: testResults!,
+        withFilters: [],
+        config: AVStockFetcherConfiguration())
     }
   }
 }

--- a/AVTestApp/AVTestApp.xcodeproj/project.pbxproj
+++ b/AVTestApp/AVTestApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		01732ED2202EDE26002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED1202EDE26002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift */; };
 		01732ED6202FDF30002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED5202FDF30002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */; };
 		01732EDA20301528002FDB91 /* AVModelParsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED920301528002FDB91 /* AVModelParsingError.swift */; };
+		01A2FE6E204B955500790FDC /* AVPerformanceTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A2FE6D204B955500790FDC /* AVPerformanceTimer.swift */; };
 		01C4F48120436ED200A2226E /* AVDateFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F48020436ED200A2226E /* AVDateFilter.swift */; };
 		01C4F4852043723700A2226E /* AVHistoricalStockPriceQueryProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F4842043723700A2226E /* AVHistoricalStockPriceQueryProtocols.swift */; };
 		01C4F4892043C7B500A2226E /* AVDateOrderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F4882043C7B500A2226E /* AVDateOrderable.swift */; };
@@ -58,6 +59,7 @@
 		01732ED1202EDE26002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVHistoricalTimeSeriesPeriodicity.swift; sourceTree = "<group>"; };
 		01732ED5202FDF30002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVHistoricalAdjustedStockPriceModel.swift; sourceTree = "<group>"; };
 		01732ED920301528002FDB91 /* AVModelParsingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVModelParsingError.swift; sourceTree = "<group>"; };
+		01A2FE6D204B955500790FDC /* AVPerformanceTimer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVPerformanceTimer.swift; sourceTree = "<group>"; };
 		01C4F48020436ED200A2226E /* AVDateFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVDateFilter.swift; sourceTree = "<group>"; };
 		01C4F4842043723700A2226E /* AVHistoricalStockPriceQueryProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVHistoricalStockPriceQueryProtocols.swift; sourceTree = "<group>"; };
 		01C4F4882043C7B500A2226E /* AVDateOrderable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVDateOrderable.swift; sourceTree = "<group>"; };
@@ -172,6 +174,7 @@
 		01F36D78200B166100512ABC /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				01A2FE6D204B955500790FDC /* AVPerformanceTimer.swift */,
 				01732EBD2021A9C2002FDB91 /* AVAPIKeyStore.swift */,
 				01732EB92020569B002FDB91 /* AVKeychainQuery.swift */,
 				01F36D79200B166100512ABC /* AVAPIKeyRegistrar.swift */,
@@ -254,6 +257,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				01732ED2202EDE26002FDB91 /* AVHistoricalTimeSeriesPeriodicity.swift in Sources */,
+				01A2FE6E204B955500790FDC /* AVPerformanceTimer.swift in Sources */,
 				01F36D7C200B166100512ABC /* AVHistoricalStockPricesQueryBuilder.swift in Sources */,
 				0144102A1FFB045600B5675B /* ViewController.swift in Sources */,
 				01732ED6202FDF30002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift in Sources */,

--- a/AVTestApp/AVTestApp/ViewController.swift
+++ b/AVTestApp/AVTestApp/ViewController.swift
@@ -85,7 +85,7 @@ class ViewController: UIViewController {
       .getResults(
         config: AVStockFetcherConfiguration(fetchQueue: .global(qos: .userInitiated), callbackQueue: .main),
         completion: { (stocks, error) in
-          print(stocks as Any)
+//          print(stocks as Any)
           print(error as Any)
         })
   }


### PR DESCRIPTION
Making the DateFormatter a singleton to avoid creating new instances over and over. Improved parsing performance from ~1s for serial parsing to 0.42s (concurrent)/ 0.55s (serial)