### PR TITLE
Fixing callback blocks

### DIFF
--- a/AVSwift/AVSwift.xcodeproj/xcshareddata/xcbaselines/014410091FFB039700B5675B.xcbaseline/314B47B5-7EA6-4ED2-A7F5-87600ED0E76D.plist
+++ b/AVSwift/AVSwift.xcodeproj/xcshareddata/xcbaselines/014410091FFB039700B5675B.xcbaseline/314B47B5-7EA6-4ED2-A7F5-87600ED0E76D.plist
@@ -16,12 +16,32 @@
 					<string>Local Baseline</string>
 				</dict>
 			</dict>
+			<key>testConcurrentParsing()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.44966</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
 			<key>testSerial()</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
 					<real>0.555</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testSerialParsing()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.60299</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/AVSwift/AVSwift/DataFetchers/AVStockDataFetcher.swift
+++ b/AVSwift/AVSwift/DataFetchers/AVStockDataFetcher.swift
@@ -21,7 +21,7 @@ public struct AVStockFetcherConfiguration {
   let callbackQueue: DispatchQueue
   
   public init(fetchQueue: DispatchQueue = DispatchQueue.global(qos: .userInitiated),
-              callbackQueue: DispatchQueue = DispatchQueue.main) {
+              callbackQueue: DispatchQueue = DispatchQueue.global(qos: .userInitiated)) {
     self.fetchQueue = fetchQueue
     self.callbackQueue = callbackQueue
   }
@@ -68,7 +68,9 @@ public class AVStockDataFetcher<ModelType: Decodable & AVDateOrderable>: NSObjec
     AVStockDataFetcher.fetchDataAsync(
       forURL: url,
       withFetchConfig: config,
-      completionBlock: completion)
+      completionBlock: { results, error in
+        config.callbackQueue.executeCallback { completion(results, error) }
+    })
   }
   
   // MARK - Internal

--- a/AVSwift/AVSwift/Extensions/AVDateFormatter.swift
+++ b/AVSwift/AVSwift/Extensions/AVDateFormatter.swift
@@ -10,11 +10,7 @@ import UIKit
 
 fileprivate let sharedDateFormatter = AVDateFormatter.dateFormatter()
 
-public enum AVDateFormatterError: Error {
-  case invalidString(String)
-}
-
-internal class AVDateFormatter {
+fileprivate class AVDateFormatter {
   
   fileprivate static func dateFormatter() -> DateFormatter {
     let dateFormatter = DateFormatter()
@@ -27,6 +23,10 @@ internal class AVDateFormatter {
       return sharedDateFormatter
     }
   }
+}
+
+public enum AVDateFormatterError: Error {
+  case invalidString(String)
 }
 
 extension String {

--- a/AVSwift/AVSwiftTests/AVSwiftTests.swift
+++ b/AVSwift/AVSwiftTests/AVSwiftTests.swift
@@ -9,31 +9,38 @@
 import XCTest
 @testable import AVSwift
 
+let startDate = try! Date.from(month: 7, day: 1, year: 2015)
+let endDate = try! Date.from(month: 9, day: 30, year: 2016)
+
 class AVSwiftTests: XCTestCase {
   
   override func setUp() {
-    AVAPIKeyStore.sharedInstance.setAPIKey(apiKey: "M8N0ZCT3MC1J9XOP")
+    AVAPIKeyStore.sharedInstance.setAPIKey(apiKey: "")
   }
   
   func testBuilders() {
     let testBuilder = AVHistoricalStandardStockPricesBuilder()
+    let beginDate = try! Date.from(month: 1, day: 1, year: 2018)
     testBuilder
       .setOutputSize(.full)
       .setSymbol("MSFT")
+      .withDateFilter(AVDateFilter.after(beginDate))
       .getResults { results, error in
         XCTAssertTrue(error == nil && results != nil)
       }
   }
   
-  func testSerial() {
+  func testSerialParsing() {
     let queue = DispatchQueue(label: "synchronous")
     var testResults: [String: [String: String]]? = nil
     queue.sync {
       AVHistoricalStandardStockPricesBuilder()
         .setOutputSize(.full)
         .setSymbol("MSFT")
+        .withDateFilter(AVDateFilter.between(startDate, endDate))
         .getRawResults { results, error in
           testResults = results
+          print(error)
         }
       sleep(5)
     }
@@ -47,16 +54,17 @@ class AVSwiftTests: XCTestCase {
     }
   }
   
-  func testConcurrent() {
+  func testConcurrentParsing() {
     let queue = DispatchQueue(label: "synchronous")
     var testResults: [String: [String: String]]? = nil
     queue.sync {
       AVHistoricalStandardStockPricesBuilder()
         .setOutputSize(.full)
+        .withDateFilter(AVDateFilter.between(startDate, endDate))
         .setSymbol("MSFT")
         .getRawResults { results, error in
           testResults = results
-      }
+        }
       sleep(5)
     }
     XCTAssertNotNil(testResults)
@@ -67,5 +75,53 @@ class AVSwiftTests: XCTestCase {
         withFilters: [],
         config: AVStockFetcherConfiguration())
     }
+  }
+  
+  func testBetweenDateFilters()
+  {
+    let queue = DispatchQueue(label: "myQueue")
+    var testResults: [AVHistoricalStockPriceModel]? = nil
+    
+    queue.sync {
+      AVHistoricalStandardStockPricesBuilder()
+        .setOutputSize(.full)
+        .withDateFilter(AVDateFilter.between(startDate, endDate))
+        .setSymbol("MSFT")
+        .getResults { results, error in
+          testResults = results
+        }
+      sleep(5)
+    }
+    XCTAssertNotNil(testResults)
+    
+    let filtered = testResults?.filter {
+      $0.date < startDate || $0.date > endDate
+    }
+    XCTAssertTrue(filtered?.count == 0)
+  }
+  
+  func testCustomFilters()
+  {
+    let queue = DispatchQueue(label: "myQueue")
+    var testResults: [AVHistoricalStockPriceModel]? = nil
+    
+    queue.sync {
+      AVHistoricalStandardStockPricesBuilder()
+        .setOutputSize(.full)
+        .withFilter({ model in
+          return model.close < model.open
+        })
+        .setSymbol("MSFT")
+        .getResults { results, error in
+          testResults = results
+        }
+      sleep(5)
+    }
+    XCTAssertNotNil(testResults)
+    
+    let filtered = testResults?.filter {
+      $0.open <= $0.close
+    }
+    XCTAssertTrue(filtered?.count == 0)
   }
 }

--- a/AVTestApp/AVTestApp/ViewController.swift
+++ b/AVTestApp/AVTestApp/ViewController.swift
@@ -85,7 +85,7 @@ class ViewController: UIViewController {
       .getResults(
         config: AVStockFetcherConfiguration(fetchQueue: .global(qos: .userInitiated), callbackQueue: .main),
         completion: { (stocks, error) in
-//          print(stocks as Any)
+          print(stocks as Any)
           print(error as Any)
         })
   }


### PR DESCRIPTION
Fix a deadlock issue involving using filters with callback queues. Having the main queue as the default callback queue was ensuring that the test would always fail.

1/ I changed the default callback queue to high pri global
2/ Added a test for testing date filters
3/ Added a test for testing custom filters
4/ Fixed callback for raw results as well, which wasn't using the designated callback queue at all