### PR TITLE
Codable errors

### DIFF
--- a/AVSwift/AVSwift.xcodeproj/project.pbxproj
+++ b/AVSwift/AVSwift.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		01732ED4202FDEB5002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED3202FDEB4002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */; };
 		01732ED820301503002FDB91 /* AVModelParsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED720301503002FDB91 /* AVModelParsingError.swift */; };
 		01A2FE6C204B94D600790FDC /* AVPerformanceTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A2FE6B204B94D600790FDC /* AVPerformanceTimer.swift */; };
+		01A2FE70204C80C300790FDC /* AVStockResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A2FE6F204C80C300790FDC /* AVStockResults.swift */; };
 		01C4F47F2043603E00A2226E /* AVDateFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F47E2043603E00A2226E /* AVDateFilter.swift */; };
 		01C4F4832043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F4822043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift */; };
 		01C4F4872043C7AD00A2226E /* AVDateOrderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F4862043C7AD00A2226E /* AVDateOrderable.swift */; };
@@ -49,6 +50,7 @@
 		01732ED3202FDEB4002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVHistoricalAdjustedStockPriceModel.swift; sourceTree = "<group>"; };
 		01732ED720301503002FDB91 /* AVModelParsingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVModelParsingError.swift; sourceTree = "<group>"; };
 		01A2FE6B204B94D600790FDC /* AVPerformanceTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVPerformanceTimer.swift; sourceTree = "<group>"; };
+		01A2FE6F204C80C300790FDC /* AVStockResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVStockResults.swift; sourceTree = "<group>"; };
 		01C4F47E2043603E00A2226E /* AVDateFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AVDateFilter.swift; path = AVSwift/DataFetchers/AVDateFilter.swift; sourceTree = SOURCE_ROOT; };
 		01C4F4822043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVHistoricalStockPriceQueryProtocols.swift; sourceTree = "<group>"; };
 		01C4F4862043C7AD00A2226E /* AVDateOrderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVDateOrderable.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 		0172A6812002D954006EF18D /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				01A2FE6F204C80C300790FDC /* AVStockResults.swift */,
 				01C4F4862043C7AD00A2226E /* AVDateOrderable.swift */,
 				01732ED3202FDEB4002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */,
 				0172A6822002D98A006EF18D /* AVHistoricalStockPriceModel.swift */,
@@ -288,6 +291,7 @@
 			files = (
 				01732EB82020556C002FDB91 /* AVKeychainQuery.swift in Sources */,
 				014410591FFC518E00B5675B /* AVStockDataFetcher.swift in Sources */,
+				01A2FE70204C80C300790FDC /* AVStockResults.swift in Sources */,
 				01F36D50200B094C00512ABC /* AVAPIKeyRegistrar.swift in Sources */,
 				01C4F4832043722E00A2226E /* AVHistoricalStockPriceQueryProtocols.swift in Sources */,
 				01732EC720243838002FDB91 /* AVDescriptionHelper.swift in Sources */,

--- a/AVSwift/AVSwift/Models/AVStockResults.swift
+++ b/AVSwift/AVSwift/Models/AVStockResults.swift
@@ -1,0 +1,37 @@
+//
+//  AVStockResults.swift
+//  AVSwift
+//
+//  Created by Roshan Goli on 3/4/18.
+//  Copyright © 2018 Roshan. All rights reserved.
+//
+
+import UIKit
+
+public final class AVStockResultsMetadata {
+  let earliestDate: Date
+  let latestDate: Date
+  let lastRefreshedDate: Date
+  let numberOfParsingErrors: Int
+  
+  init(earliestDate: Date,
+       latestDate: Date,
+       lastRefreshedDate: Date,
+       numberOfParsingErrors: Int) {
+    self.earliestDate = earliestDate
+    self.latestDate = latestDate
+    self.lastRefreshedDate = lastRefreshedDate
+    self.numberOfParsingErrors = numberOfParsingErrors
+  }
+}
+
+public final class AVStockResults<Model>{
+  let timeSeries: [Model]
+  let metadata: AVStockResultsMetadata
+  
+  init(timeSeries: [Model],
+       metadata: AVStockResultsMetadata) {
+    self.timeSeries = timeSeries
+    self.metadata = metadata
+  }
+}

--- a/AVSwift/AVSwiftTests/AVSwiftTests.swift
+++ b/AVSwift/AVSwiftTests/AVSwiftTests.swift
@@ -69,7 +69,7 @@ class AVSwiftTests: XCTestCase {
     XCTAssertNotNil(testResults)
     
     self.measure {
-      let _ = AVStockDataFetcher<AVHistoricalStockPriceModel>.concurrentParsing(
+      let _ = try! ConcurrentParser<AVHistoricalStockPriceModel>.parse(
         input: testResults!,
         withFilters: [],
         config: AVStockFetcherConfiguration())

--- a/AVSwift/AVSwiftTests/AVSwiftTests.swift
+++ b/AVSwift/AVSwiftTests/AVSwiftTests.swift
@@ -20,11 +20,10 @@ class AVSwiftTests: XCTestCase {
   
   func testBuilders() {
     let testBuilder = AVHistoricalStandardStockPricesBuilder()
-    let beginDate = try! Date.from(month: 1, day: 1, year: 2018)
     testBuilder
       .setOutputSize(.full)
       .setSymbol("MSFT")
-      .withDateFilter(AVDateFilter.after(beginDate))
+      .withDateFilter(AVDateFilter.after(startDate))
       .getResults { results, error in
         XCTAssertTrue(error == nil && results != nil)
       }

--- a/AVSwift/AVSwiftTests/AVSwiftTests.swift
+++ b/AVSwift/AVSwiftTests/AVSwiftTests.swift
@@ -46,7 +46,7 @@ class AVSwiftTests: XCTestCase {
     XCTAssertNotNil(testResults)
     
     self.measure {
-       let _ = AVStockDataFetcher<AVHistoricalStockPriceModel>.serialParsing(
+       let _ = try! SerialParser<AVHistoricalStockPriceModel>.parse(
         input: testResults!,
         withFilters: [],
         config: AVStockFetcherConfiguration())

--- a/AVTestApp/AVTestApp.xcodeproj/project.pbxproj
+++ b/AVTestApp/AVTestApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		01732ED6202FDF30002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED5202FDF30002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */; };
 		01732EDA20301528002FDB91 /* AVModelParsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01732ED920301528002FDB91 /* AVModelParsingError.swift */; };
 		01A2FE6E204B955500790FDC /* AVPerformanceTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A2FE6D204B955500790FDC /* AVPerformanceTimer.swift */; };
+		01A2FE72204C80CD00790FDC /* AVStockResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A2FE71204C80CD00790FDC /* AVStockResults.swift */; };
 		01C4F48120436ED200A2226E /* AVDateFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F48020436ED200A2226E /* AVDateFilter.swift */; };
 		01C4F4852043723700A2226E /* AVHistoricalStockPriceQueryProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F4842043723700A2226E /* AVHistoricalStockPriceQueryProtocols.swift */; };
 		01C4F4892043C7B500A2226E /* AVDateOrderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01C4F4882043C7B500A2226E /* AVDateOrderable.swift */; };
@@ -60,6 +61,7 @@
 		01732ED5202FDF30002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVHistoricalAdjustedStockPriceModel.swift; sourceTree = "<group>"; };
 		01732ED920301528002FDB91 /* AVModelParsingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVModelParsingError.swift; sourceTree = "<group>"; };
 		01A2FE6D204B955500790FDC /* AVPerformanceTimer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVPerformanceTimer.swift; sourceTree = "<group>"; };
+		01A2FE71204C80CD00790FDC /* AVStockResults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVStockResults.swift; sourceTree = "<group>"; };
 		01C4F48020436ED200A2226E /* AVDateFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVDateFilter.swift; sourceTree = "<group>"; };
 		01C4F4842043723700A2226E /* AVHistoricalStockPriceQueryProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVHistoricalStockPriceQueryProtocols.swift; sourceTree = "<group>"; };
 		01C4F4882043C7B500A2226E /* AVDateOrderable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVDateOrderable.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 		01F36D72200B166000512ABC /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				01A2FE71204C80CD00790FDC /* AVStockResults.swift */,
 				01C4F4882043C7B500A2226E /* AVDateOrderable.swift */,
 				01732ED920301528002FDB91 /* AVModelParsingError.swift */,
 				01732ED5202FDF30002FDB91 /* AVHistoricalAdjustedStockPriceModel.swift */,
@@ -264,6 +267,7 @@
 				01F36D7A200B166100512ABC /* AVStockDataFetcher.swift in Sources */,
 				01F36D7D200B166100512ABC /* AVQueryBuilder.swift in Sources */,
 				01732EDA20301528002FDB91 /* AVModelParsingError.swift in Sources */,
+				01A2FE72204C80CD00790FDC /* AVStockResults.swift in Sources */,
 				01F36D7E200B166100512ABC /* AVQueryBuilderCommon.swift in Sources */,
 				01C4F48120436ED200A2226E /* AVDateFilter.swift in Sources */,
 				01732ECE20243ED2002FDB91 /* AVDateFormatter.swift in Sources */,


### PR DESCRIPTION
1/ Convert parsers to a protocol so compiler forces us to make changes to both at the same time
2/ Add failOnParsingError configuration if there is a desire for total data sanity
3/ Add wrapper object (still unused) that takes in the model array and metadata
4/ Add trys everywhere