### PR TITLE
change return type to new wrapper

### DIFF
--- a/AVSwift/AVSwift/Models/AVStockResults.swift
+++ b/AVSwift/AVSwift/Models/AVStockResults.swift
@@ -9,18 +9,18 @@
 import UIKit
 
 public final class AVStockResultsMetadata {
-  let earliestDate: Date
-  let latestDate: Date
-  let lastRefreshedDate: Date
+  let earliestDate: Date?
+  let latestDate: Date?
+//  let lastRefreshedDate: Date
   let numberOfParsingErrors: Int
   
-  init(earliestDate: Date,
-       latestDate: Date,
-       lastRefreshedDate: Date,
+  init(earliestDate: Date?,
+       latestDate: Date?,
+//       lastRefreshedDate: Date,
        numberOfParsingErrors: Int) {
     self.earliestDate = earliestDate
     self.latestDate = latestDate
-    self.lastRefreshedDate = lastRefreshedDate
+//    self.lastRefreshedDate = lastRefreshedDate
     self.numberOfParsingErrors = numberOfParsingErrors
   }
 }

--- a/AVSwift/AVSwift/QueryBuilders/AVQueryBuilderCommon.swift
+++ b/AVSwift/AVSwift/QueryBuilders/AVQueryBuilderCommon.swift
@@ -17,7 +17,7 @@ protocol AVQueryBuilderProtocol: class {
   
   func getResults(
     config: AVStockFetcherConfiguration,
-    completion: @escaping ([ModelType]?, Error?) -> Void)
+    completion: @escaping ParsedStockCompletion<ModelType>)
   func getRawResults(
     config: AVStockFetcherConfiguration,
     completion: @escaping ([String: [String: String]]?, Error?) -> Void)

--- a/AVSwift/AVSwiftTests/AVSwiftTests.swift
+++ b/AVSwift/AVSwiftTests/AVSwiftTests.swift
@@ -79,7 +79,7 @@ class AVSwiftTests: XCTestCase {
   func testBetweenDateFilters()
   {
     let queue = DispatchQueue(label: "myQueue")
-    var testResults: [AVHistoricalStockPriceModel]? = nil
+    var testResults: AVStockResults<AVHistoricalStockPriceModel>? = nil
     
     queue.sync {
       AVHistoricalStandardStockPricesBuilder()
@@ -93,7 +93,7 @@ class AVSwiftTests: XCTestCase {
     }
     XCTAssertNotNil(testResults)
     
-    let filtered = testResults?.filter {
+    let filtered = testResults?.timeSeries.filter {
       $0.date < startDate || $0.date > endDate
     }
     XCTAssertTrue(filtered?.count == 0)
@@ -102,7 +102,7 @@ class AVSwiftTests: XCTestCase {
   func testCustomFilters()
   {
     let queue = DispatchQueue(label: "myQueue")
-    var testResults: [AVHistoricalStockPriceModel]? = nil
+    var testResults: AVStockResults<AVHistoricalStockPriceModel>? = nil
     
     queue.sync {
       AVHistoricalStandardStockPricesBuilder()
@@ -118,7 +118,7 @@ class AVSwiftTests: XCTestCase {
     }
     XCTAssertNotNil(testResults)
     
-    let filtered = testResults?.filter {
+    let filtered = testResults?.timeSeries.filter {
       $0.open <= $0.close
     }
     XCTAssertTrue(filtered?.count == 0)


### PR DESCRIPTION
1/ Make getResults return type be a wrapper with the time series and other metadata as objects

Need to fix the numberOfParsingErrors variable. Right now it also includes dates that are filtered out because of the filters