### PR TITLE
Move stock fetcher configuration to builder

### DIFF
--- a/AVSwift/AVSwift/QueryBuilders/AVQueryBuilder.swift
+++ b/AVSwift/AVSwift/QueryBuilders/AVQueryBuilder.swift
@@ -15,13 +15,16 @@ public enum AVOutputSize: String {
 
 public protocol AVQueryBuilderBase {
   func setOutputSize(_ outputSize: AVOutputSize) -> Self
+  func setConfiguration(_ config: AVStockFetcherConfiguration) -> Self
 }
 
 public class AVQueryBuilder: NSObject {
   open var outputSize: AVOutputSize
+  open var config: AVStockFetcherConfiguration
   
   override init() {
     outputSize = .compact
+    config = AVStockFetcherConfiguration()
     
     super.init()
   }
@@ -44,4 +47,10 @@ public class AVQueryBuilder: NSObject {
     self.outputSize = outputSize
     return self
   }
+  
+  public func setConfiguration(_ config: AVStockFetcherConfiguration) -> Self {
+    self.config = config
+    return self
+  }
+  
 }

--- a/AVSwift/AVSwift/QueryBuilders/AVQueryBuilderCommon.swift
+++ b/AVSwift/AVSwift/QueryBuilders/AVQueryBuilderCommon.swift
@@ -14,13 +14,10 @@ protocol AVQueryBuilderProtocol: class {
   func buildURL() -> URL
   
   var modelFilters: [ModelFilter<ModelType>] { get }
+  var config: AVStockFetcherConfiguration { get }
   
-  func getResults(
-    config: AVStockFetcherConfiguration,
-    completion: @escaping ParsedStockCompletion<ModelType>)
-  func getRawResults(
-    config: AVStockFetcherConfiguration,
-    completion: @escaping UnparsedStockCompletion)
+  func getResults(_ completion: @escaping ParsedStockCompletion<ModelType>)
+  func getRawResults(_ completion: @escaping UnparsedStockCompletion)
 }
 
 extension AVQueryBuilderProtocol {
@@ -30,16 +27,12 @@ extension AVQueryBuilderProtocol {
   }
   
   // convenience methods to go straight from the query builder to the results
-  public func getResults(
-    config: AVStockFetcherConfiguration = AVStockFetcherConfiguration(),
-    completion: @escaping ParsedStockCompletion<ModelType>)
+  public func getResults(_ completion: @escaping ParsedStockCompletion<ModelType>)
   {
     self.build(withFilters: self.modelFilters).getResults(config: config, completion: completion)
   }
   
-  public func getRawResults(
-    config: AVStockFetcherConfiguration = AVStockFetcherConfiguration(),
-    completion: @escaping UnparsedStockCompletion)
+  public func getRawResults(_ completion: @escaping UnparsedStockCompletion)
   {
     self.build(withFilters: self.modelFilters).getRawResults(config: config, completion: completion)
   }

--- a/AVTestApp/AVTestApp/ViewController.swift
+++ b/AVTestApp/AVTestApp/ViewController.swift
@@ -84,16 +84,16 @@ class ViewController: UIViewController {
     AVHistoricalStandardStockPricesBuilder()
       .setSymbol("MSFT")
       .setPeriodicity(selectedPeriodicity)
+      .setConfiguration(
+        AVStockFetcherConfiguration(
+        fetchQueue: .global(qos: .userInitiated),
+        callbackQueue: .main,
+        failOnParsingError: true))
       .withDateFilter(AVDateFilter.between(beginDate, endDate))
-      .getResults(
-        config: AVStockFetcherConfiguration(
-          fetchQueue: .global(qos: .userInitiated),
-          callbackQueue: .main,
-          failOnParsingError: true),
-        completion: { stocks, error in
+      .getResults { stocks, error in
           print(stocks?.timeSeries as Any)
           print(error as Any)
-        })
+    }
   }
 }
 


### PR DESCRIPTION
Moving the stock fetcher configuration to AVQueryBuilder instead of being passed in through the `getResults` function. This will make the getResults function simpler because all that needs to be passed in is the completion block.